### PR TITLE
Fix progress bar height

### DIFF
--- a/src/Controller.html
+++ b/src/Controller.html
@@ -257,7 +257,7 @@
 
   .rr-progress {
     width: 100%;
-    height: 4px;
+    height: 12px;
     background: #eee;
     position: relative;
     border-radius: 3px;


### PR DESCRIPTION
The height of the progress bar needs to be updated since the adding of top & bottom border for .rr-progress class.

I have only tested on last Chrome, Firefox, Safari, but it's some classic CSS here.