### PR TITLE
Update rrwebPlayer types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,7 +14,7 @@ export default class rrwebPlayer extends SvelteComponent {
       speedOption?: number[];
       showController?: boolean;
       tags?: Record<string, string>;
-    } & playerConfig;
+    } & Partial<playerConfig>;
   });
 
   addEventListener(event: string, handler: (params: any) => unknown): void;


### PR DESCRIPTION
Without this change, the following fails to compile in typescript:

```js
new rrwebPlayer({
    target: document.body,
    props: {
        width: 900,
        events,
        autoPlay: true,
    },
})
```