### PR TITLE
2 commits for optimizing chore

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postcss-easy-import": "^3.0.0",
     "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
-    "rollup-plugin-svelte": "^5.0.3",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^5.1.2",
     "sirv-cli": "^0.4.4",
     "svelte": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^7.0.0",
     "@rollup/plugin-typescript": "^4.0.0",
-    "@tsconfig/svelte": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
     "eslint": "^7.5.0",
@@ -24,7 +23,8 @@
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "rrweb": "^0.9.10"
+    "rrweb": "^0.9.10",
+    "@tsconfig/svelte": "^1.0.0"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
I push 2 commits. 

## commit: 303d9fd

fix the bug when build svelte application.

When using **rollup-plugin-svelte**, there is a error:
![image](https://user-images.githubusercontent.com/35675374/100874661-e0467f80-34df-11eb-890d-ecdea45fe981.png)

And I find the solution at [Error: Package subpath './compiler.js' is not defined by "exports" in node_modules/svelte/package.json](https://github.com/Samuel-Martineau/generator-svelte/issues/7).

And update the **rollup-plugin-svelte** in package.json, install, build again: 
![image](https://user-images.githubusercontent.com/35675374/100874895-33b8cd80-34e0-11eb-8305-c2f6e862acfe.png)


## commit: a5c3447
I am building a react component base on rrweb-player with typescript, and when I run `npx tsc`, there is an error with typescript: 
![image](https://user-images.githubusercontent.com/35675374/100881086-7aaac100-34e8-11eb-8f0b-204ec33f8acb.png)
It seems that because of the use of the @tsconfig/svelte/tsconfig.json in devDependencies. Could move it to the dependencies for convinence when building other framework component? 
