### PR TITLE
Allow goto to specify if it should play or pause

### DIFF
--- a/src/Controller.svelte
+++ b/src/Controller.svelte
@@ -141,13 +141,14 @@
     replayer.pause();
   };
 
-  export const goto = (timeOffset: number) => {
+  export const goto = (timeOffset: number, play?: boolean) => {
     currentTime = timeOffset;
-    const isPlaying = playerState === 'playing';
-    replayer.pause();
-    replayer.play(timeOffset);
-    if (!isPlaying) {
-      replayer.pause();
+    const resumePlaying =
+      typeof play === 'boolean' ? play : playerState === 'playing';
+    if (resumePlaying) {
+      replayer.play(timeOffset);
+    } else {
+      replayer.pause(timeOffset);
     }
   };
 

--- a/src/Player.svelte
+++ b/src/Player.svelte
@@ -109,8 +109,8 @@
   export const pause = () => {
     controller.pause();
   };
-  export const goto = (timeOffset: number) => {
-    controller.goto(timeOffset);
+  export const goto = (timeOffset: number, play?: boolean) => {
+    controller.goto(timeOffset, play);
   };
 
   onMount(() => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,5 +32,5 @@ export default class rrwebPlayer extends SvelteComponent {
   triggerResize: () => void;
   play: () => void;
   pause: () => void;
-  goto: (timeOffset: number) => void;
+  goto: (timeOffset: number, play?: boolean) => void;
 }


### PR DESCRIPTION
Allows you to specify if what type of behaviour you'd like to achieve after moving to a specific point in time.

Also uses `pause(timeoffset)` internally which has fixed some issues in the past.